### PR TITLE
`cloud_llm.py` fix

### DIFF
--- a/docs/running_api.md
+++ b/docs/running_api.md
@@ -23,8 +23,12 @@ This repository includes a FastAPI application that serves as the backend API fo
 1. **Startup:**
      Run the API with:
      ```bash
-     uvicorn app.main:app --reload
+     uvicorn fast-api.main_api_local:app --reload
      ```
+     or
+    ```bash
+    uvicorn fast-api.main_api_cloud:app --reload
+    ```
 2. **Endpoints:**
      Access endpoints at `http://localhost:8000`.
      Example:

--- a/docs/running_app.md
+++ b/docs/running_app.md
@@ -1,8 +1,8 @@
 # Running the Flask web interface
 
 In order to run the user UI, which has a website interface that relies on the API,
-you can use a sample Flask web interface.
-In order to initiate that, make sure that the API is running and then start up the app:
+you can use a sample Flask web interface. You may need to do this in 2 separate terminals.
+In order to initiate that, **[make sure that the API is running first](https://github.com/datasciencecampus/statschat-global/blob/cloud_fix/docs/running_api.md)** and then start up the app:
 
 ```shell
 python flask-app/app.py

--- a/flask-app/templates/statschat.html
+++ b/flask-app/templates/statschat.html
@@ -34,7 +34,7 @@
             <p class="search__results__meta font-size--16">
             <b>Released on:</b> {{row['date']}}  &nbsp;  | &nbsp;
             <b>Section: </b> <a href="{{row['section_url']}}"> {{ row['section'] }}</a>  &nbsp;  | &nbsp;
-            <b>Semantic distance: </b> {{row['score']}}
+            <b>Match Score: </b> {{row['score']}}
             </p>
             <p class="search__results__summary font-size--16">
             <b>Context:</b>  {{row['page_content']|safe }}

--- a/flask-app/templates/statschat.html
+++ b/flask-app/templates/statschat.html
@@ -14,6 +14,9 @@
         <script src="{{ url_for('static',filename='js/rating.js') }}"></script>
         </div>
     <div aria-live="polite">
+        <b>Please note:</b> the lower the <b>Score</b>, the more relevant the publication is to your question.
+        <br> <br>
+    <div aria-live="polite">
         Your question:
     <h4 class="ons-u-fs-xxl">  {{question}} </h4>
 </div>
@@ -34,7 +37,7 @@
             <p class="search__results__meta font-size--16">
             <b>Released on:</b> {{row['date']}}  &nbsp;  | &nbsp;
             <b>Section: </b> <a href="{{row['section_url']}}"> {{ row['section'] }}</a>  &nbsp;  | &nbsp;
-            <b>Match Score: </b> {{row['score']}}
+            <b>Score: </b> {{row['score']}}
             </p>
             <p class="search__results__summary font-size--16">
             <b>Context:</b>  {{row['page_content']|safe }}

--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -20,7 +20,7 @@ split_overlap = 200
 latest_only = true
 
 [search]
-generative_model_name = "mistralai/Mistral-7B-Instruct-v0.3"
+generative_model_name = ""mistralai/Mistral-Nemo-Base-2407""
 # Alternatives for the generative LLM include:
 # - text-unicorn
 # - text-bison@001

--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -20,14 +20,15 @@ split_overlap = 200
 latest_only = true
 
 [search]
-generative_model_name = "mistralai/Mistral-Nemo-Base-2407"
+generative_model_name = "google/bigbird-pegasus-large-arxiv" # "facebook/bart-large"
 # Alternatives for the generative LLM include:
 # - text-unicorn
 # - text-bison@001
-# - google/flan-t5-large
 # - lmsys/fastchat-t5-3b-v1.0
 # - google/flan-t5-large
 # - google/flan-ul2
+# - google/bigbird-pegasus-large-arxiv # can handle more input tokens
+# - google/t5-3b # can handle more input tokens
 k_docs = 2
 k_contexts = 5
 similarity_threshold = 2.0     # Threshold score below which a document is returned in a search

--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -20,7 +20,7 @@ split_overlap = 200
 latest_only = true
 
 [search]
-generative_model_name = ""mistralai/Mistral-Nemo-Base-2407""
+generative_model_name = "mistralai/Mistral-Nemo-Base-2407"
 # Alternatives for the generative LLM include:
 # - text-unicorn
 # - text-bison@001

--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -20,7 +20,7 @@ split_overlap = 200
 latest_only = true
 
 [search]
-generative_model_name = "google/bigbird-pegasus-large-arxiv" # "facebook/bart-large"
+generative_model_name = "mistralai/Mistral-7B-Instruct-v0.3" # "facebook/bart-large"
 # Alternatives for the generative LLM include:
 # - text-unicorn
 # - text-bison@001
@@ -28,7 +28,7 @@ generative_model_name = "google/bigbird-pegasus-large-arxiv" # "facebook/bart-la
 # - google/flan-t5-large
 # - google/flan-ul2
 # - google/bigbird-pegasus-large-arxiv # can handle more input tokens
-# - google/t5-3b # can handle more input tokens
+
 k_docs = 2
 k_contexts = 5
 similarity_threshold = 2.0     # Threshold score below which a document is returned in a search

--- a/statschat/generative/cloud_llm.py
+++ b/statschat/generative/cloud_llm.py
@@ -3,7 +3,7 @@ import os
 import json
 from pathlib import Path
 from dotenv import load_dotenv
-from langchain_huggingface import HuggingFaceEndpoint
+#from langchain_huggingface import HuggingFaceEndpoint
 from langchain_community.vectorstores import FAISS
 from langchain_huggingface.embeddings import HuggingFaceEmbeddings
 from langchain.docstore.document import Document
@@ -15,7 +15,6 @@ from statschat.generative.prompts_cloud import (
     EXTRACTIVE_PROMPT_PYDANTIC,
     STUFF_DOCUMENT_PROMPT,
 )
-from transformers import pipeline
 from functools import lru_cache
 from statschat.generative.utils import deduplicator, highlighter
 from statschat.embedding.latest_flag_helpers import time_decay
@@ -29,7 +28,7 @@ class Inquirer:
 
     def __init__(
         self,
-        generative_model_name: str = "google/flan-t5-large",
+        generative_model_name: str = "google/bigbird-pegasus-large-arxiv",
         faiss_db_root: str = "data/db_langchain",
         # change faiss_db_root_latest to "data/db_langchain_latest" after "UPDATE"
         faiss_db_root_latest: str = "data/db_langchain",
@@ -82,6 +81,7 @@ class Inquirer:
         self.stuff_document_prompt = STUFF_DOCUMENT_PROMPT
 
         # Load the token for Hugging Face
+        # Only needed if using HuggingFaceEndpoint
         load_dotenv()
         sec_key = os.getenv("HF_TOKEN")
 

--- a/statschat/generative/cloud_llm.py
+++ b/statschat/generative/cloud_llm.py
@@ -9,7 +9,8 @@ from langchain_huggingface.embeddings import HuggingFaceEmbeddings
 from langchain.docstore.document import Document
 from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain.output_parsers import PydanticOutputParser
-from langchain_community.llms.huggingface_pipeline import HuggingFacePipeline
+#from langchain_community.llms.huggingface_pipeline import HuggingFacePipeline
+from langchain_huggingface import HuggingFaceEndpoint
 from statschat.generative.response_model import LlmResponse
 from statschat.generative.prompts_cloud import (
     EXTRACTIVE_PROMPT_PYDANTIC,
@@ -28,7 +29,7 @@ class Inquirer:
 
     def __init__(
         self,
-        generative_model_name: str = "google/bigbird-pegasus-large-arxiv",
+        generative_model_name: str = "mistralai/Mistral-7B-Instruct-v0.3",
         faiss_db_root: str = "data/db_langchain",
         # change faiss_db_root_latest to "data/db_langchain_latest" after "UPDATE"
         faiss_db_root_latest: str = "data/db_langchain",
@@ -86,14 +87,14 @@ class Inquirer:
         sec_key = os.getenv("HF_TOKEN")
 
         # Load LLM with text2text-generation specifications
-        self.llm = HuggingFacePipeline.from_model_id(
-                model_id=generative_model_name,
-                task="text2text-generation",
-                model_kwargs={
-                    "temperature": llm_temperature,
-                    "max_length": llm_max_tokens,
-                },
-            )
+        self.llm = HuggingFaceEndpoint(
+            repo_id=generative_model_name,
+            provider="transformers",
+            task="text2text-generation",
+            max_new_tokens=llm_max_tokens,
+            do_sample=False,
+            huggingfacehub_api_token=sec_key,
+        )
 
         # Embeddings
         embeddings = HuggingFaceEmbeddings(model_name=embedding_model_name)


### PR DESCRIPTION
- Added fix for `cloud_llm.py` as appears Huggingface no longer providing support for text generation models via `HuggingFaceEndpoint` https://python.langchain.com/api_reference/huggingface/llms/langchain_huggingface.llms.huggingface_endpoint.HuggingFaceEndpoint.html
- Now using local model with `cloud_llm.py` but architecture still the same but now API token from hugging face not required
- Checked flask app and works with `main_api_local.py` and `main_api_cloud.py`
- Updated documentation to make it clearer that API needs to first be active before using web app