### PR TITLE
page_url for manually uploaded PDFs

### DIFF
--- a/statschat/config/main.toml
+++ b/statschat/config/main.toml
@@ -10,7 +10,7 @@ embedding_model_name = "sentence-transformers/all-mpnet-base-v2"
 
 [preprocess]
 download_mode = "SETUP" # Either "SETUP" or "UPDATE"
-download_site = "" # Leave empty if PDFS are placed manually in the data/pdf_store folder.
+download_site = "" # Leave empty if PDFS are placed manually in `data/local_pdfs`.
 data_dir = "data/"
 download_dir = "pdf_store"
 directory = "json_conversions"

--- a/statschat/pdf_processing/pdf_to_json.py
+++ b/statschat/pdf_processing/pdf_to_json.py
@@ -258,6 +258,15 @@ def extract_pdf_text(pdf_file_path: Path, pdf_url: str) -> list:
                 text = text.replace("\n", "")
 
             page_link = f"{pdf_url}#page={page_num}"
+            
+            # For Manual PDF upload
+            if "https://www." not in page_link:
+                page_link = "http://localhost:8000/" + page_link
+            
+            # Stay the same
+            else:
+                page_link = page_link
+                
             pages_text.append(
                 {
                     "page_number": page_num,


### PR DESCRIPTION
- Updated `extract_pdf_text` function with a localhost for `page_url`, now should be able to access link of manually uploaded PDF
- Previously this was not functioning in json files, local and cloud.llm or the flask app

- Links work with local_llm.py

**You will need to do these below:**

- Do a fresh run of `python3 statschat/pdf_runner.py`  in SETUP

First navigate to `local_pdfs` dir
```
cd statschat-global/data/local_pdfs
```
Run in terminal (`-m` may not be needed depending on your setup)
```
python3 -m http.server 8000
```
or

```
python -m http.server 8000
```

You should see the below in the terminal

<img width="1382" height="178" alt="image" src="https://github.com/user-attachments/assets/68cf4eb6-2f8d-4096-9516-caf85df6b681" />
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/81a542ea-4c31-416d-858d-504fc3b8f577" />
<img width="1490" height="1092" alt="image" src="https://github.com/user-attachments/assets/8201781d-4f63-4888-a72b-766ecfc5970d" />

- Should now function same as if PDFs were webscraped with link taking you directly to the document page 
- Updated main.toml so folder needing to put manually downloaded PDFs is correct